### PR TITLE
Add support for building a snap of dframe 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,10 +3,10 @@ base: core18 # the base snap is the execution environment for this snap
 version: git
 summary: Put device frames around your mobile/web/progressive app screenshots
 description: |
-  This is my-snap's description. You have a paragraph or two to tell the
-  most important story about your snap. Keep it under 100 words though,
-  we live in tweetspace and your description wants to look good in the snap
-  store.
+  Pass in filenames, file globs, websites urls, or image urls. In any combination or order.
+  dframe will prompt for the frames you want to use. Select multiple frames and 
+  search by typing. Once all the frames are selected, hit ESC.
+  The frames will be downloaded from a CDN and cached locally in case they need re-using.
 
 grade: stable
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,8 +4,8 @@ version: git
 summary: Put device frames around your mobile/web/progressive app screenshots
 description: |
   Pass in filenames, file globs, websites urls, or image urls. In any combination or order.
-  dframe will prompt for the frames you want to use. Select multiple frames and 
-  search by typing. Once all the frames are selected, hit ESC.
+  dframe will prompt for the frames to use. Select multiple frames and search by typing. 
+  Once all the frames are selected, hit ESC.
   The frames will be downloaded from a CDN and cached locally in case they need re-using.
 
 grade: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: dframe
+base: core18 # the base snap is the execution environment for this snap
+version: git
+summary: Put device frames around your mobile/web/progressive app screenshots
+description: |
+  This is my-snap's description. You have a paragraph or two to tell the
+  most important story about your snap. Keep it under 100 words though,
+  we live in tweetspace and your description wants to look good in the snap
+  store.
+
+grade: stable
+confinement: strict
+
+parts:
+  deviceframe:
+    plugin: nodejs
+    nodejs-version: "8.14.0"
+    source: .
+    build-packages:
+      - build-essential
+    stage-packages:
+      - libpng16-16
+      - libfreetype6
+      - libfontconfig1
+      - fontconfig-config
+
+apps:
+  dframe:
+    command: bin/dframe
+    environment:
+      FONTCONFIG_PATH: "$SNAP/etc/fonts"
+    plugs:
+      - network
+      - home
+      - removable-media


### PR DESCRIPTION
I created a snap package of deviceframe so it can be featured in the [Snap Store](https://snapcraft.io/store), which is a cross-distribution app-store for Linux. Once in the store, it can be easily installed via ‘snap install’ or via GNOME Software or KDE Discover on most distros.

A single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

Given the command is ‘dframe’ I configured the yaml to use that as the snap name and exposed the command under the same name. If you’d prefer we could use the full ‘deviceframe’ name for the snap, and request an ‘alias’ in the store, which would expose the command as ‘dframe’.

If you're willing to publish this under the dframe project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the dframe name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of dframe, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via your existing travis CI / release process.

I appreciate you may not be aware of snaps and snapcraft, and I’d of course be happy to answer any questions you may have. 
