### PR TITLE
fix(fs) remove double quotes from frame path

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -315,7 +315,7 @@ function downloadFrame(frame) {
 
   bar.tick();
 
-  frame.path = path.join(frameCacheDir, frame.relPath);
+  frame.path = path.join(frameCacheDir, frame.relPath).replace(/\"/gi, '');
 
   const downloadDir = path.parse(frame.path).dir;
   mkdirp.sync(downloadDir);

--- a/cli.js
+++ b/cli.js
@@ -315,7 +315,7 @@ function downloadFrame(frame) {
 
   bar.tick();
 
-  frame.path = path.join(frameCacheDir, frame.relPath).replace(/\"/gi, '');
+  frame.path = path.join(frameCacheDir, frame.relPath).replace(/"/gi, '');
 
   const downloadDir = path.parse(frame.path).dir;
   mkdirp.sync(downloadDir);


### PR DESCRIPTION
In relation with issue #26 